### PR TITLE
Disambiguate action

### DIFF
--- a/README.org
+++ b/README.org
@@ -86,11 +86,13 @@
    re-executes it if it is known and if prompting was not requested.
 
 ** ~autobuild-nice~
-   Rule priorities may be specified via a top-level directive ~(autobuild-nice N)~ within a rule's body,
-   with lower nice values denoting higher priority. A rule priority controls the default rule selected by
-   ~autobuild-build~. The most specific rule under a certain context should strive to have the highest priority
-   in order for ~autobuild-build~ to select it as the default. \\
-   The exact mechanism for specifying rule priorities may change in the future.
+   A rule may specify the priority of its action by setting the value of
+   ~autobuild-nice~, with lower nice values denoting higher priority.
+   ~autobuild-build~ defaults to selecting the action with the highest priority, unless
+   prompting was requested via a prefix argument.
+
+   The most specific rule under a certain context should strive to have the highest priority
+   in order for ~autobuild-build~ to select it as the default.
 
 ** ~autobuild-pipeline~
    Several build rules may be chained together to form compilation-pipelines. (TODO example)

--- a/autobuild-test.el
+++ b/autobuild-test.el
@@ -79,7 +79,7 @@
       (letf (((symbol-function #'autobuild-candidate-select)
               (lambda (cands _prompt _stringify-fn)
                 (cl-loop for action in cands
-                         thereis (when (eq (autobuild-action-rule action)
+                         thereis (when (eq (autobuild--invocation-rule action)
                                            #'high-nice)
                                    action)))))
         (autobuild-build t)

--- a/autobuild.el
+++ b/autobuild.el
@@ -138,7 +138,6 @@
 
 (defun autobuild-pipeline-run (rules-remaining)
   "Run the RULES-REMAINING of an autobuild pipeline.  See ‘autobuild-pipeline'."
-  (error "Not implemented")
   (when rules-remaining
     (cl-destructuring-bind (buffer rule-or-action) (car rules-remaining)
       (unless rule-or-action

--- a/autobuild.el
+++ b/autobuild.el
@@ -63,7 +63,7 @@
    with lower values commanding a higher priority.")
 
 (defconst autobuild-nice-default 10
-  "Default nice value for rule actions that do not setq the variable ‘autobuild-nice’.")
+  "Default nice value for rule invocations that do not setq the variable ‘autobuild-nice’.")
 
 (defun autobuild-nice (nice)
   "A function wrapper for a rule to set the current action's NICE value."

--- a/autobuild.el
+++ b/autobuild.el
@@ -196,8 +196,8 @@
                thereis (and (boundp mode)
                             (symbol-value mode)))))
 
-;; internal struct used to collect rule's action and it's specified "nice" priority
-(cl-defstruct autobuild-action rule action nice)
+;; internal struct used to collect a rule's action and it's nice value
+(cl-defstruct autobuild--invocation rule action nice)
 
 (defun autobuild-applicable-rule-actions ()
   "Return a list of the currently applicable build actions.
@@ -208,12 +208,12 @@
            for rule in (reverse autobuild-rules-list)
            do (if-let* ((autobuild-nice autobuild-nice-default)
                         (action (autobuild-rule-action rule)))
-                  (push (make-autobuild-action :rule rule
-                                               :action action
-                                               :nice autobuild-nice)
+                  (push (make-autobuild--invocation :rule rule
+                                                    :action action
+                                                    :nice autobuild-nice)
                         actions))
            finally
-           (return (autobuild--sort-by #'autobuild-action-nice actions))))
+           (return (autobuild--sort-by #'autobuild--invocation-nice actions))))
 
 (defvar-local autobuild-last-rule nil)
 
@@ -236,25 +236,25 @@
                     (last-rule-valid (autobuild-rule-p autobuild-last-rule))
                     (action (autobuild-rule-action autobuild-last-rule)))
               ;; the last action is still applicable, and prompt was not forced
-              (list (make-autobuild-action :rule autobuild-last-rule
-                                           :action action
-                                           :nice 0))
+              (list (make-autobuild--invocation :rule autobuild-last-rule
+                                                :action action
+                                                :nice 0))
             ;; fall back to generating actions for all applicable rules
             (autobuild-applicable-rule-actions)))
          (choice (cond ((null cands) (error "No build rules matched"))
                        ((not prompt) (car cands))
                        (t (autobuild-candidate-select
                            cands "select build rule: "
-                           #'autobuild-action-to-string)))))
+                           #'autobuild--invocation-to-string)))))
     (cl-assert choice)
-    (setq-local autobuild-last-rule (autobuild-action-rule choice))
-    (autobuild-run-action (autobuild-action-action choice))))
+    (setq-local autobuild-last-rule (autobuild--invocation-rule choice))
+    (autobuild-run-action (autobuild--invocation-action choice))))
 
-(defun autobuild-action-to-string (action)
+(defun autobuild--invocation-to-string (action)
   "Generate a string representation of an autobuild ACTION."
   (format "%s (%s)"
-          (autobuild-action-rule action)
-          (autobuild-action-nice action)))
+          (autobuild--invocation-rule action)
+          (autobuild--invocation-nice action)))
 
 (defvar-local autobuild-last-executed-action nil)
 
@@ -369,9 +369,8 @@
 (defun autobuild-delete-rule (rule)
   "Delete the RULE from the autobuild rules registry."
   (interactive
-   (list (autobuild-candidate-select
-          autobuild-rules-list "select rule to delete: "
-          #'symbol-name)))
+   (list (autobuild-candidate-select autobuild-rules-list
+                                     "select rule to delete: ")))
   (cl-assert (autobuild-rule-p rule))
   (setq autobuild-rules-list (delq rule autobuild-rules-list)))
 
@@ -408,7 +407,7 @@
                             collect (cons hint cand)))))
 
 (defun autobuild-candidate-select (candidates &optional prompt stringify-fn
-                                         autoselect-if-single)
+                                              autoselect-if-single)
   "Use PROMPT to prompt for a selection from CANDIDATES."
   (let* ((hints-cands (autobuild-candidate-hints candidates))
          (sep ") ")

--- a/autobuild.el
+++ b/autobuild.el
@@ -416,11 +416,10 @@
          (prompt (or prompt "select candidate: "))
          (choice (if (and autoselect-if-single (null (cdr choices)))
                      (car choices)
-                     (minibuffer-with-setup-hook
-                     #'minibuffer-completion-help
-                   (completing-read prompt choices
-                                    nil
-                                    t))))
+                   (minibuffer-with-setup-hook #'minibuffer-completion-help
+                     (completing-read prompt choices
+                                      nil
+                                      t))))
          (cand (let* ((hint (car (split-string choice sep))))
                  (cdr (assoc hint hints-cands #'equal)))))
     cand))


### PR DESCRIPTION
- disambiguate "action" as referenced by doc from internal autobuild--invocation struct
- fix outdated autobuild-nice documentation in README.org